### PR TITLE
Resetting 'first' in the ConcatEnumerator*.Reset methods

### DIFF
--- a/src/StructLinq/Concat/ConcatEnumerator.cs
+++ b/src/StructLinq/Concat/ConcatEnumerator.cs
@@ -38,6 +38,7 @@ namespace StructLinq.Concat
         {
             enumerator1.Reset();
             enumerator2.Reset();
+            first = true;
         }
 
         public T Current

--- a/src/StructLinq/Concat/RefConcatEnumerator.cs
+++ b/src/StructLinq/Concat/RefConcatEnumerator.cs
@@ -38,6 +38,7 @@ namespace StructLinq.Concat
         {
             enumerator1.Reset();
             enumerator2.Reset();
+            first = true;
         }
 
         public ref T Current


### PR DESCRIPTION
Presently, `first` isn't being reset in the `Reset` methods, meaning that if the `Enumerator` were already processing the second enumerator when `Reset` were called, it would continue from the second `Enumerator`.